### PR TITLE
Fix incorrect lookahead in token

### DIFF
--- a/peg/parser.y
+++ b/peg/parser.y
@@ -386,7 +386,7 @@ DOTASTERISK          <- '.*'               skip
 DOTQUESTIONMARK      <- '.?'               skip
 EQUAL                <- '='      ![>=]     skip
 EQUALEQUAL           <- '=='               skip
-EQUALRARROW          <- '=>'     ![>]      skip
+EQUALRARROW          <- '=>'               skip
 EXCLAMATIONMARK      <- '!'      ![=]      skip
 EXCLAMATIONMARKEQUAL <- '!='               skip
 LARROW               <- '<'      ![<=]     skip


### PR DESCRIPTION
Caused by a typo in the original that I missed. `=>>` is not a token, but `>>=` is.